### PR TITLE
add offset

### DIFF
--- a/cyberland.php
+++ b/cyberland.php
@@ -62,19 +62,22 @@ function get(string $board): void
     global $username;
     global $password;
 
+	$offset = intval($_GET['offset'] ?? 0);
     $num = intval($_GET['num'] ?? 50);
 
         $conn = new PDO("mysql:host={$servername};port={$port};dbname={$dbname}", $username, $password);
     if (isset($_GET["thread"])) {
-        $sql = "SELECT * FROM ".$board." WHERE replyTo=? OR id=? ORDER BY id DESC LIMIT ?";
+        $sql = "SELECT * FROM ".$board." WHERE replyTo=? OR id=? ORDER BY id DESC LIMIT ?,?";
         $s = $conn->prepare($sql);
         $s->bindParam(1, $_GET["thread"], PDO::PARAM_INT);
         $s->bindParam(2, $_GET["thread"], PDO::PARAM_INT);
-        $s->bindParam(3, $num, PDO::PARAM_INT);
+		$s->bindParam(3, $offset, PDO::PARAM_INT);
+        $s->bindParam(4, $num, PDO::PARAM_INT);
     } else {
-        $sql = "SELECT * FROM {$board} ORDER BY id DESC LIMIT ?";
+        $sql = "SELECT * FROM {$board} ORDER BY id DESC LIMIT ?,?";
         $s = $conn->prepare($sql);
-        $s->bindParam(1, $num, PDO::PARAM_INT);
+		$s->bindParam(1, $offset, PDO::PARAM_INT);
+        $s->bindParam(2, $num, PDO::PARAM_INT);
     }
     $s->execute();
     $r = $s->fetchAll();

--- a/tut.txt
+++ b/tut.txt
@@ -5,5 +5,5 @@ Tutorial
 POST /o content=x&replyTo=y
  - This will create a post to the off topic board containing the content x and replying to y, if y is unspecified, then it will be considered that it does not reply to anything.
 * Retrieving posts
-GET cyberland2.club/o/?thread=x&num=y
- - This will get y number of posts from the off topic board that reply to post number x with the newest first as a JSON object. If x is unspecified, just y number of recent posts will be returned. The number of posts you can recieve at once may be limited at some point depending on how this goes.
+GET cyberland2.club/o/?thread=x&num=y&offset=z
+ - This will get y number of posts from the off topic board that reply to post number x with the newest first as a JSON object. If x is unspecified, just y number of recent posts will be returned. The number of posts you can recieve at once may be limited at some point depending on how this goes. You can specify an offset z to skip z posts from the start.


### PR DESCRIPTION
at the moment, clients have to do pagination themselves, and throw away a lot of results when this can be done on the server
this uses the two-parameter version of `LIMIT` and adds an optional parameter `offset` which specifies the number of posts to skip
this is also non-breaking since `LIMIT` with one parameter is just the same as the two-parameter one with the first one defaulting to 0